### PR TITLE
Fix compatibility with Carp < 1.25

### DIFF
--- a/t/exports.t
+++ b/t/exports.t
@@ -4,6 +4,9 @@ use warnings;
 use Test::More 0.88;
 use Test::Warnings 0.009 ':no_end_test', ':all';
 
+require Carp;
+my $period = ($Carp::VERSION >= 1.25) ? "." : "";
+
 my $line;
 {
     package Foo;
@@ -20,13 +23,13 @@ can_ok( Foo => qw(warn show carp dump) );
 
 is_deeply(
     [ warnings { Foo::w } ],
-    [ "[ \"foo\" ] at " . __FILE__ . " line $line.\n" ],
+    [ "[ \"foo\" ] at " . __FILE__ . " line $line$period\n" ],
     'warn',
 );
 
 is_deeply(
     [ warnings { Foo::c; $line = __LINE__ } ],
-    [ "[ \"foo\" ] at " . __FILE__ . " line $line.\n" ],
+    [ "[ \"foo\" ] at " . __FILE__ . " line $line$period\n" ],
     'carp',
 );
 
@@ -38,7 +41,7 @@ is_deeply(
 
 is_deeply(
     [ warnings { is_deeply(Foo::s, ['foo'], 'show') } ],
-    [ "[ \"foo\" ] at " . __FILE__ . " line $line.\n" ],
+    [ "[ \"foo\" ] at " . __FILE__ . " line $line$period\n" ],
     'show warns and shows',
 );
 


### PR DESCRIPTION
Carp 1.25 made a change to its formatting, adding a period at the end of the
message. This can mess up tests and code that are looking for error messages.

See also https://metacpan.org/pod/Carp::Fix::1_25